### PR TITLE
Use both IPv4+IPv6 sockets to check whether a port is free.

### DIFF
--- a/src/portpicker.py
+++ b/src/portpicker.py
@@ -55,6 +55,10 @@ def bind(port, socket_type, socket_proto):
     This is primarily a helper function for PickUnusedPort, used to see
     if a particular port number is available.
 
+    For the port to be considered available, the kernel must support at least
+    one of (IPv6, IPv4), and the port must be available on each supported
+    family.
+
     Args:
       port: The port number to bind to, or 0 to have the OS pick a free port.
       socket_type: The type of the socket (ex: socket.SOCK_STREAM).
@@ -63,15 +67,24 @@ def bind(port, socket_type, socket_proto):
     Returns:
       The port number on success or None on failure.
     """
-    sock = socket.socket(socket.AF_INET, socket_type, socket_proto)
-    try:
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        sock.bind(('', port))
-        return sock.getsockname()[1]
-    except socket.error:
-        return None
-    finally:
-        sock.close()
+    got_socket = False
+    for family in (socket.AF_INET6, socket.AF_INET):
+        try:
+            sock = socket.socket(family, socket_type, socket_proto)
+            got_socket = True
+        except socket.error:
+            continue
+        try:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.bind(('', port))
+            if socket_type == socket.SOCK_STREAM:
+                sock.listen(1)
+            port = sock.getsockname()[1]
+        except socket.error:
+            return None
+        finally:
+            sock.close()
+    return port if got_socket else None
 
 Bind = bind  # legacy API. pylint: disable=invalid-name
 

--- a/src/portpicker.py
+++ b/src/portpicker.py
@@ -97,8 +97,7 @@ def is_port_free(port):
     Returns:
       boolean, whether it is free to use for both TCP and UDP
     """
-    return (bind(port, _PROTOS[0][0], _PROTOS[0][1]) and
-            bind(port, _PROTOS[1][0], _PROTOS[1][1]))
+    return bind(port, *_PROTOS[0]) and bind(port, *_PROTOS[1])
 
 IsPortFree = is_port_free  # legacy API. pylint: disable=invalid-name
 

--- a/src/portserver.py
+++ b/src/portserver.py
@@ -58,6 +58,7 @@ def _get_process_start_time(pid):
         return 0
 
 
+# TODO: Consider importing portpicker.bind() instead of duplicating the code.
 def _bind(port, socket_type, socket_proto):
     """Try to bind to a socket of the specified type, protocol, and port.
 
@@ -101,8 +102,7 @@ def _is_port_free(port):
     Returns:
       boolean, whether it is free to use for both TCP and UDP
     """
-    return (_bind(port, _PROTOS[0][0], _PROTOS[0][1]) and
-            _bind(port, _PROTOS[1][0], _PROTOS[1][1]))
+    return _bind(port, *_PROTOS[0]) and _bind(port, *_PROTOS[1])
 
 
 def _should_allocate_port(pid):


### PR DESCRIPTION
This allows the portpicker to function in dual-stack and IPv4/IPv6-only
environments.

For a port to be considered available, the kernel must support at least
one of (IPv6, IPv4), and the port must be available on each supported
family.

Use identical/redundant implementations of bind() and is_port_free()
between portpicker and portserver.  I am assuming that these were
intentionally designed as self-contained programs, instead of sharing a
common library.