### PR TITLE
Print socket error details in get_port_from_port_server

### DIFF
--- a/src/portpicker.py
+++ b/src/portpicker.py
@@ -202,7 +202,7 @@ def get_port_from_port_server(portserver_address, pid=None):
         finally:
             sock.close()
     except socket.error as e:
-        print('Socket error when connecting to portserver: ' + str(e),
+        print('Socket error when connecting to portserver:', e,
               file=sys.stderr)
         return None
 

--- a/src/portpicker.py
+++ b/src/portpicker.py
@@ -201,8 +201,9 @@ def get_port_from_port_server(portserver_address, pid=None):
             buf = sock.recv(1024)
         finally:
             sock.close()
-    except socket.error:
-        print('Socket error when connecting to portserver.', file=sys.stderr)
+    except socket.error as e:
+        print('Socket error when connecting to portserver: ' + str(e),
+              file=sys.stderr)
         return None
 
     try:


### PR DESCRIPTION
For debugging purposes, it seems important to include details of the actual socket.error .  Otherwise we are left to wonder what happened.