### PR TITLE
Don't continually ask the OS for a port

### DIFF
--- a/src/portpicker.py
+++ b/src/portpicker.py
@@ -142,7 +142,7 @@ def pick_unused_port(pid=None):
         the current process's PID is used.
 
     Returns:
-      A port number that is unused on both TCP and UDP.
+      A port number that is unused on both TCP and UDP. None on error.
     """
     if _free_ports:
         port = _free_ports.pop()
@@ -178,16 +178,19 @@ def _pick_unused_port_without_server():  # Protected. pylint: disable=invalid-na
             _random_ports.add(port)
             return port
 
-    # Try OS-assigned ports next.
+    # Next, try a few times to get an OS-assigned port.
     # Ambrose discovered that on the 2.6 kernel, calling Bind() on UDP socket
     # returns the same port over and over. So always try TCP first.
-    while True:
+    for _ in range(10):
         # Ask the OS for an unused port.
         port = bind(0, _PROTOS[0][0], _PROTOS[0][1])
         # Check if this port is unused on the other protocol.
         if port and bind(port, _PROTOS[1][0], _PROTOS[1][1]):
             _random_ports.add(port)
             return port
+
+    # Give up.
+    return None
 
 
 def get_port_from_port_server(portserver_address, pid=None):

--- a/src/tests/portpicker_test.py
+++ b/src/tests/portpicker_test.py
@@ -181,10 +181,14 @@ class PickUnusedPortTest(unittest.TestCase):
                 return None
 
         with mock.patch.object(portpicker, 'bind', bind_with_error):
+            got_at_least_one_port = False
             for _ in range(100):
                 port = portpicker._pick_unused_port_without_server()
-                self.assertTrue(self.IsUnusedTCPPort(port))
-                self.assertTrue(self.IsUnusedUDPPort(port))
+                if port is not None:
+                    got_at_least_one_port = True
+                    self.assertTrue(self.IsUnusedTCPPort(port))
+                    self.assertTrue(self.IsUnusedUDPPort(port))
+            self.assertTrue(got_at_least_one_port)
 
     def testIsPortFree(self):
         """This might be flaky unless this test is run with a portserver."""


### PR DESCRIPTION
On very busy machines, we might not be able to get a port from the OS
that is free on both TCP and UDP. Rather than spinning forever, only try
a handful of times, then return None, as described in the docstring.