### PR TITLE
Added Support for Linux On Power

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 os: linux
+arch:
+  - amd64
+  - ppc64le
 dist: xenial
 script:
   - ./test.sh


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/ujjwalsh/python_portpicker/builds/210335852 
Please have a look.

Regards,
ujjwal