### PR TITLE
Add Windows support for the port server

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pytest tox
-          if exist requirements.txt pip install -r requirements.txt
+          if (Test-Path "requirements.txt") { pip install -r requirements.txt }
       - name: Test with tox
         run: |
           # Run tox using the version of Python in `PATH`

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10.0-beta.1']
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10.0-beta.3']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10.0-beta.1']
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10.0-beta.3']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,7 +6,7 @@ name: Python Portpicker & Portserver
 on: [push]
 
 jobs:
-  build:
+  build-ubuntu:
 
     runs-on: ubuntu-latest
     strategy:
@@ -25,6 +25,30 @@ jobs:
           python -m pip install --upgrade pip
           pip install pytest tox
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Test with tox
+        run: |
+          # Run tox using the version of Python in `PATH`
+          tox -e py
+
+  build-windows:
+
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10.0-beta.1']
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest tox
+          if exist requirements.txt pip install -r requirements.txt
       - name: Test with tox
         run: |
           # Run tox using the version of Python in `PATH`

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,10 @@
+## 1.5.0
+
+*   Add portserver support to Windows using named pipes. To create or connect
+    to a server, prefix the name of the server with `@` (e.g. 
+    `@unittest-portserver`).
+
+
 ## 1.4.0
 
 *   Use `async def` instead of `@asyncio.coroutine` in order to support 3.10.

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ platforms = POSIX
 requires =
 
 [options]
+install_requires = psutil
 python_requires = >= 3.6
 package_dir=
     =src

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 # https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files
 [metadata]
 name = portpicker
-version = 1.4.1b1
+version = 1.5.0b1
 maintainer = Google LLC
 maintainer_email = greg@krypto.org
 license = Apache 2.0
@@ -29,7 +29,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
-platforms = POSIX
+platforms = POSIX, Windows
 requires =
 
 [options]

--- a/src/portpicker.py
+++ b/src/portpicker.py
@@ -266,7 +266,7 @@ def _get_windows_port_from_port_server(portserver_address, pid):
             0,
             0)
 
-        _winapi.WriteFile(handle, str(pid).encode('utf-8'))
+        _winapi.WriteFile(handle, ('%d\n' % pid).encode('ascii'))
         data, _ = _winapi.ReadFile(handle, 6, 0)
         return data
     except FileNotFoundError as error:

--- a/src/portpicker.py
+++ b/src/portpicker.py
@@ -253,9 +253,12 @@ def _get_linux_port_from_port_server(portserver_address, pid):
 
 
 def _get_windows_port_from_port_server(portserver_address, pid):
+    if portserver_address[0] == '@':
+        portserver_address = '\\\\.\\pipe\\' + portserver_address[1:]
+
     try:
         handle = _winapi.CreateFile(
-            "\\\\.\\pipe\\" + portserver_address,
+            portserver_address,
             _winapi.GENERIC_READ | _winapi.GENERIC_WRITE,
             0,
             0,

--- a/src/portpicker.py
+++ b/src/portpicker.py
@@ -45,6 +45,8 @@ import sys
 
 if sys.platform == 'win32':
     import _winapi
+else:
+    _winapi = None
 
 # The legacy Bind, IsPortFree, etc. names are not exported.
 __all__ = ('bind', 'is_port_free', 'pick_unused_port', 'return_port',
@@ -301,7 +303,7 @@ def get_port_from_port_server(portserver_address, pid=None):
     if pid is None:
         pid = os.getpid()
 
-    if sys.platform == 'win32':
+    if _winapi:
         buf = _get_windows_port_from_port_server(portserver_address, pid)
     else:
         buf = _get_linux_port_from_port_server(portserver_address, pid)

--- a/src/portserver.py
+++ b/src/portserver.py
@@ -386,7 +386,7 @@ def main():
         server_address = config.portserver_windows_pipe_address
     else:
         event_loop.add_signal_handler(
-            signal.SIGUSR1, request_handler.dump_stats)
+            signal.SIGUSR1, request_handler.dump_stats) # pylint: disable=no-member
 
         old_py_loop = {'loop': event_loop} if sys.version_info < (3, 10) else {}
         coro = asyncio.start_unix_server(
@@ -407,7 +407,7 @@ def main():
 
     if sys.platform != 'win32':
         event_loop.run_until_complete(server.wait_closed())
-        event_loop.remove_signal_handler(signal.SIGUSR1)
+        event_loop.remove_signal_handler(signal.SIGUSR1) # pylint: disable=no-member
 
     event_loop.close()
     request_handler.dump_stats()

--- a/src/tests/portpicker_test.py
+++ b/src/tests/portpicker_test.py
@@ -27,6 +27,8 @@ from contextlib import ExitStack
 
 if sys.platform == 'win32':
     import _winapi
+else:
+    _winapi = None
 
 try:
     # pylint: disable=no-name-in-module
@@ -105,7 +107,7 @@ class PickUnusedPortTest(unittest.TestCase):
 
     def testSendsPidToPortServer(self):
         with ExitStack() as stack:
-            if sys.platform == 'win32':
+            if _winapi:
                 create_file_mock = mock.Mock()
                 create_file_mock.return_value = 0
                 read_file_mock = mock.Mock()
@@ -136,7 +138,7 @@ class PickUnusedPortTest(unittest.TestCase):
             stack.enter_context(
                 mock.patch.object(os, 'getpid', return_value=9876))
 
-            if sys.platform == 'win32':
+            if _winapi:
                 create_file_mock = mock.Mock()
                 create_file_mock.return_value = 0
                 read_file_mock = mock.Mock()
@@ -163,7 +165,7 @@ class PickUnusedPortTest(unittest.TestCase):
     @mock.patch.dict(os.environ,{'PORTSERVER_ADDRESS': 'portserver'})
     def testReusesPortServerPorts(self):
         with ExitStack() as stack:
-            if sys.platform == 'win32':
+            if _winapi:
                 read_file_mock = mock.Mock()
                 read_file_mock.side_effect = [
                     (b'12345\n', 0),
@@ -313,7 +315,7 @@ class PickUnusedPortTest(unittest.TestCase):
         ]
 
         # Using v6only=0 on Windows doesn't result in collisions
-        if sys.platform != 'win32':
+        if not _winapi:
             cases.extend([
                 (socket.AF_INET6, socket.SOCK_STREAM, 0),
                 (socket.AF_INET6, socket.SOCK_DGRAM,  0),

--- a/src/tests/portpicker_test.py
+++ b/src/tests/portpicker_test.py
@@ -23,6 +23,10 @@ import random
 import socket
 import sys
 import unittest
+from contextlib import ExitStack
+
+if sys.platform == 'win32':
+    import _winapi
 
 try:
     # pylint: disable=no-name-in-module
@@ -100,27 +104,82 @@ class PickUnusedPortTest(unittest.TestCase):
             self.assertTrue(self.IsUnusedUDPPort(port))
 
     def testSendsPidToPortServer(self):
-        server = mock.Mock()
-        server.recv.return_value = b'42768\n'
-        with mock.patch.object(socket, 'socket', return_value=server):
-            port = portpicker.get_port_from_port_server('portserver', pid=1234)
-            server.sendall.assert_called_once_with(b'1234\n')
+        with ExitStack() as stack:
+            if sys.platform == 'win32':
+                create_file_mock = mock.Mock()
+                create_file_mock.return_value = 0
+                read_file_mock = mock.Mock()
+                write_file_mock = mock.Mock()
+                read_file_mock.return_value = (b'42768\n', 0)
+                stack.enter_context(
+                    mock.patch('_winapi.CreateFile', new=create_file_mock))
+                stack.enter_context(
+                    mock.patch('_winapi.WriteFile', new=write_file_mock))
+                stack.enter_context(
+                    mock.patch('_winapi.ReadFile', new=read_file_mock))
+                port = portpicker.get_port_from_port_server(
+                    'portserver', pid=1234)
+                write_file_mock.assert_called_once_with(0, b'1234\n')
+            else:
+                server = mock.Mock()
+                server.recv.return_value = b'42768\n'
+                stack.enter_context(
+                    mock.patch.object(socket, 'socket', return_value=server))
+                port = portpicker.get_port_from_port_server(
+                    'portserver', pid=1234)
+                server.sendall.assert_called_once_with(b'1234\n')
+
         self.assertEqual(port, 42768)
 
     def testPidDefaultsToOwnPid(self):
-        server = mock.Mock()
-        server.recv.return_value = b'52768\n'
-        with mock.patch.object(socket, 'socket', return_value=server):
-            with mock.patch.object(os, 'getpid', return_value=9876):
+        with ExitStack() as stack:
+            stack.enter_context(
+                mock.patch.object(os, 'getpid', return_value=9876))
+
+            if sys.platform == 'win32':
+                create_file_mock = mock.Mock()
+                create_file_mock.return_value = 0
+                read_file_mock = mock.Mock()
+                write_file_mock = mock.Mock()
+                read_file_mock.return_value = (b'52768\n', 0)
+                stack.enter_context(
+                    mock.patch('_winapi.CreateFile', new=create_file_mock))
+                stack.enter_context(
+                    mock.patch('_winapi.WriteFile', new=write_file_mock))
+                stack.enter_context(
+                    mock.patch('_winapi.ReadFile', new=read_file_mock))
+                port = portpicker.get_port_from_port_server('portserver')
+                write_file_mock.assert_called_once_with(0, b'9876\n')
+            else:
+                server = mock.Mock()
+                server.recv.return_value = b'52768\n'
+                stack.enter_context(
+                    mock.patch.object(socket, 'socket', return_value=server))
                 port = portpicker.get_port_from_port_server('portserver')
                 server.sendall.assert_called_once_with(b'9876\n')
+
         self.assertEqual(port, 52768)
 
     @mock.patch.dict(os.environ,{'PORTSERVER_ADDRESS': 'portserver'})
     def testReusesPortServerPorts(self):
-        server = mock.Mock()
-        server.recv.side_effect = [b'12345\n', b'23456\n', b'34567\n']
-        with mock.patch.object(socket, 'socket', return_value=server):
+        with ExitStack() as stack:
+            if sys.platform == 'win32':
+                read_file_mock = mock.Mock()
+                read_file_mock.side_effect = [
+                    (b'12345\n', 0),
+                    (b'23456\n', 0),
+                    (b'34567\n', 0),
+                ]
+                stack.enter_context(mock.patch('_winapi.CreateFile'))
+                stack.enter_context(mock.patch('_winapi.WriteFile'))
+                stack.enter_context(
+                    mock.patch('_winapi.ReadFile', new=read_file_mock))
+            else:
+                server = mock.Mock()
+                server.recv.side_effect = [b'12345\n', b'23456\n', b'34567\n']
+                stack.enter_context(
+                    mock.patch.object(socket, 'socket', return_value=server))
+
             self.assertEqual(portpicker.pick_unused_port(), 12345)
             self.assertEqual(portpicker.pick_unused_port(), 23456)
             portpicker.return_port(12345)
@@ -248,12 +307,18 @@ class PickUnusedPortTest(unittest.TestCase):
 
         cases = [
             (socket.AF_INET,  socket.SOCK_STREAM, None),
-            (socket.AF_INET6, socket.SOCK_STREAM, 0),
             (socket.AF_INET6, socket.SOCK_STREAM, 1),
             (socket.AF_INET,  socket.SOCK_DGRAM,  None),
-            (socket.AF_INET6, socket.SOCK_DGRAM,  0),
             (socket.AF_INET6, socket.SOCK_DGRAM,  1),
         ]
+
+        # Using v6only=0 on Windows doesn't result in collisions
+        if sys.platform != 'win32':
+            cases.extend([
+                (socket.AF_INET6, socket.SOCK_STREAM, 0),
+                (socket.AF_INET6, socket.SOCK_DGRAM,  0),
+            ])
+
         for (sock_family, sock_type, v6only) in cases:
             # Occupy the port on a subset of possible protocols.
             try:

--- a/src/tests/portserver_test.py
+++ b/src/tests/portserver_test.py
@@ -40,7 +40,7 @@ import portserver
 def setUpModule():
     portserver._configure_logging(verbose=True)
 
-def fork_process():
+def exit_immediately():
     os._exit(0)
 
 class PortserverFunctionsTest(unittest.TestCase):
@@ -114,7 +114,7 @@ class PortserverFunctionsTest(unittest.TestCase):
         self.assertFalse(portserver._should_allocate_port(1))
         self.assertTrue(portserver._should_allocate_port, os.getpid())
 
-        p = Process(target=fork_process)
+        p = Process(target=exit_immediately)
         p.start()
         child_pid = p.pid
         p.join()

--- a/src/tests/portserver_test.py
+++ b/src/tests/portserver_test.py
@@ -25,14 +25,23 @@ import sys
 import time
 import unittest
 from unittest import mock
+from multiprocessing import Process
 
 import portpicker
+
+# On Windows, portserver.py is located in the "Scripts" folder, which isn't
+# added to the import path by default
+if sys.platform == 'win32':
+    sys.path.append(os.path.join(os.path.split(sys.executable)[0]))
+
 import portserver
 
 
 def setUpModule():
     portserver._configure_logging(verbose=True)
 
+def fork_process():
+    os._exit(0)
 
 class PortserverFunctionsTest(unittest.TestCase):
 
@@ -53,12 +62,18 @@ class PortserverFunctionsTest(unittest.TestCase):
 
         cases = [
             (socket.AF_INET,  socket.SOCK_STREAM, None),
-            (socket.AF_INET6, socket.SOCK_STREAM, 0),
             (socket.AF_INET6, socket.SOCK_STREAM, 1),
             (socket.AF_INET,  socket.SOCK_DGRAM,  None),
-            (socket.AF_INET6, socket.SOCK_DGRAM,  0),
             (socket.AF_INET6, socket.SOCK_DGRAM,  1),
         ]
+
+        # Using v6only=0 on Windows doesn't result in collisions
+        if sys.platform != 'win32':
+            cases.extend([
+                (socket.AF_INET6, socket.SOCK_STREAM, 0),
+                (socket.AF_INET6, socket.SOCK_DGRAM,  0),
+            ])
+
         for (sock_family, sock_type, v6only) in cases:
             # Occupy the port on a subset of possible protocols.
             try:
@@ -68,6 +83,10 @@ class PortserverFunctionsTest(unittest.TestCase):
                       file=sys.stderr)
                 # Skip this case, since we cannot occupy a port.
                 continue
+
+            if not hasattr(socket, 'IPPROTO_IPV6'):
+                v6only = None
+
             if v6only is not None:
                 try:
                     sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY,
@@ -94,11 +113,12 @@ class PortserverFunctionsTest(unittest.TestCase):
         self.assertFalse(portserver._should_allocate_port(0))
         self.assertFalse(portserver._should_allocate_port(1))
         self.assertTrue(portserver._should_allocate_port, os.getpid())
-        child_pid = os.fork()
-        if child_pid == 0:
-            os._exit(0)
-        else:
-            os.waitpid(child_pid, 0)
+
+        p = Process(target=fork_process)
+        p.start()
+        child_pid = p.pid
+        p.join()
+
         # This test assumes that after waitpid returns the kernel has finished
         # cleaning the process.  We also assume that the kernel will not reuse
         # the former child's pid before our next call checks for its existence.


### PR DESCRIPTION
Using the port server to avoid race conditions was only working on Unix, so this change attemps to extend the support to Windows by using named pipes.

This adds Windows for issue #5 