### PR TITLE
bind(0) before probing for random available ports.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,9 @@
+## 1.5.1
+
+*   When not using a portserver *(you really should)*, try the `bind(0)`
+    approach before hunting for random unused ports. More reliable per
+    https://github.com/google/python_portpicker/issues/16.
+
 ## 1.5.0
 
 *   Add portserver support to Windows using named pipes. To create or connect to

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 # https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files
 [metadata]
 name = portpicker
-version = 1.5.0
+version = 1.5.1b1
 maintainer = Google LLC
 maintainer_email = greg@krypto.org
 license = Apache 2.0

--- a/src/portpicker.py
+++ b/src/portpicker.py
@@ -198,14 +198,6 @@ def _pick_unused_port_without_server():  # Protected. pylint: disable=invalid-na
     Raises:
       NoFreePortFoundError: No free port could be found.
     """
-    # Try random ports first.
-    rng = random.Random()
-    for _ in range(10):
-        port = int(rng.randrange(15000, 25000))
-        if is_port_free(port):
-            _random_ports.add(port)
-            return port
-
     # Next, try a few times to get an OS-assigned port.
     # Ambrose discovered that on the 2.6 kernel, calling Bind() on UDP socket
     # returns the same port over and over. So always try TCP first.
@@ -214,6 +206,14 @@ def _pick_unused_port_without_server():  # Protected. pylint: disable=invalid-na
         port = bind(0, _PROTOS[0][0], _PROTOS[0][1])
         # Check if this port is unused on the other protocol.
         if port and bind(port, _PROTOS[1][0], _PROTOS[1][1]):
+            _random_ports.add(port)
+            return port
+
+    # Try random ports as a last resort.
+    rng = random.Random()
+    for _ in range(10):
+        port = int(rng.randrange(15000, 25000))
+        if is_port_free(port):
             _random_ports.add(port)
             return port
 


### PR DESCRIPTION
When not using a portserver, assume that the OS knows best. This
should improve reliability.

Though the best thing to do is to use a portserver...

Addresses https://github.com/google/python_portpicker/issues/16
