### PR TITLE
Adds an optional timeout that a port will remain bound to after the CLI exits

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
-## 1.6.x
+## 1.6.0b1
 
+*   Add -h and --help text to the command line tool.
+*   When portpicker is used as a command line tool from a script, allow for
+    ports chosen *without a portserver* to be kept bound to a socket by a child
+    process for a user specified timeout.  This hack *attempts* to minimize race
+    conditions. It at least prevents multiple subsequent portserver CLI
+    invocations from choosing the same port.
 *   Some pylint based refactorings to portpicker and portpicker\_test.
 *   Drop 3.6 from our CI test matrix and metadata. It probably still works
     there, but expect our unittests to include 3.7-ism's in the future. We'll

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,9 +3,9 @@
 *   Add -h and --help text to the command line tool.
 *   When portpicker is used as a command line tool from a script, allow for
     ports chosen *without a portserver* to be kept bound to a socket by a child
-    process for a user specified timeout.  This hack *attempts* to minimize race
+    process for a user specified timeout. This hack *attempts* to minimize race
     conditions. It at least prevents multiple subsequent portserver CLI
-    invocations from choosing the same port.
+    invocations within the timeout window from choosing the same port.
 *   Some pylint based refactorings to portpicker and portpicker\_test.
 *   Drop 3.6 from our CI test matrix and metadata. It probably still works
     there, but expect our unittests to include 3.7-ism's in the future. We'll

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,11 +4,11 @@
 *   The command line interface now defaults to associating the returned port
     with its parent process PID (usually the calling script) when no argument
     was given as that makes more sense.
-*   When portpicker is used as a command line tool from a script, allow for
-    ports chosen *without a portserver* to be kept bound to a socket by a child
-    process for a user specified timeout. This hack *attempts* to minimize race
-    conditions. It at least prevents multiple subsequent portserver CLI
-    invocations within the timeout window from choosing the same port.
+*   When portpicker is used as a command line tool from a script, if a port is
+    chosen without a portserver it can now be kept bound to a socket by a
+    child process for a user specified timeout. When successful, this helps
+    minimize race conditions as subsequent portpicker CLI invocations within
+    the timeout window cannot choose the same port.
 *   Some pylint based refactorings to portpicker and portpicker\_test.
 *   Drop 3.6 from our CI test matrix and metadata. It probably still works
     there, but expect our unittests to include 3.7-ism's in the future. We'll

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,9 @@
 ## 1.6.0b1
 
 *   Add -h and --help text to the command line tool.
+*   The command line interface now defaults to associating the returned port
+    with its parent process PID (usually the calling script) when no argument
+    was given as that makes more sense.
 *   When portpicker is used as a command line tool from a script, allow for
     ports chosen *without a portserver* to be kept bound to a socket by a child
     process for a user specified timeout. This hack *attempts* to minimize race

--- a/src/portpicker.py
+++ b/src/portpicker.py
@@ -264,13 +264,15 @@ def _spawn_bound_port_holding_daemon(port, bound_sockets, timeout):
             if fork_pid == 0:
                 # This child process inherits and holds bound_sockets open
                 # for bind_timeout seconds.
-                os.close(sys.stdin.fileno())
-                os.close(sys.stdout.fileno())
-                os.close(sys.stderr.fileno())
-                time.sleep(timeout)
-                for held_socket in bound_sockets:
-                    held_socket.close()
-                sys.exit(0)
+                try:
+                    os.close(sys.stdin.fileno())
+                    os.close(sys.stdout.fileno())
+                    os.close(sys.stderr.fileno())
+                    time.sleep(timeout)
+                    for held_socket in bound_sockets:
+                        held_socket.close()
+                finally:
+                    sys.exit(0)
 
 
 def _pick_unused_port_without_server(bind_timeout=0):

--- a/src/portpicker.py
+++ b/src/portpicker.py
@@ -118,10 +118,10 @@ Bind = bind  # legacy API. pylint: disable=invalid-name
 
 
 def _bind(port, socket_type, socket_proto, return_socket=None, return_family=socket.AF_INET6):
-    """Internal implementation of bind() with an additional internal arg.
+    """Internal implementation of bind.
 
     Args:
-      port, socket_type, socket_proto: see bind.
+      port, socket_type, socket_proto: see bind().
       return_socket: If supplied, a list that we will append an open bound
           reuseaddr socket on the port in question to.
       return_family: The socket family to return in return_socket.

--- a/src/portpicker.py
+++ b/src/portpicker.py
@@ -114,8 +114,6 @@ def bind(port, socket_type, socket_proto):
     """
     return _bind(port, socket_type, socket_proto)
 
-Bind = bind  # legacy API. pylint: disable=invalid-name
-
 
 def _bind(port, socket_type, socket_proto, return_socket=None, return_family=socket.AF_INET6):
     """Internal implementation of bind.
@@ -160,7 +158,6 @@ def _bind(port, socket_type, socket_proto, return_socket=None, return_family=soc
     return port if got_socket else None
 
 
-
 def is_port_free(port):
     """Check if specified port is free.
 
@@ -170,8 +167,6 @@ def is_port_free(port):
       boolean, whether it is free to use for both TCP and UDP
     """
     return _is_port_free(port)
-
-IsPortFree = is_port_free  # legacy API. pylint: disable=invalid-name
 
 
 def _is_port_free(port, return_sockets=None):
@@ -210,8 +205,6 @@ def pick_unused_port(pid=None, portserver_address=None):
     """
     return _pick_unused_port(pid, portserver_address)
 
-PickUnusedPort = pick_unused_port  # legacy API. pylint: disable=invalid-name
-
 
 def _pick_unused_port(pid=None, portserver_address=None,
                      noserver_bind_timeout=0):
@@ -245,6 +238,7 @@ def _pick_unused_port(pid=None, portserver_address=None,
     return _pick_unused_port_without_server(bind_timeout=noserver_bind_timeout)
 
 
+
 def _spawn_bound_port_holding_daemon(port, bound_sockets, timeout):
     """If possible, fork()s a daemon process to hold bound_sockets open.
 
@@ -262,8 +256,8 @@ def _spawn_bound_port_holding_daemon(port, bound_sockets, timeout):
             import time
             fork_pid = os.fork()  # This concept only works on POSIX.
         except Exception as err:
-            print('WARNING: Cannot timeout unbind of port', port, '-',
-                  err, file=sys.stderr)
+            print('WARNING: Cannot timeout unbinding close of port', port,
+                  ' closing on exit. -', err, file=sys.stderr)
         else:
             if fork_pid == 0:
                 # This child process inherits and holds bound_sockets open
@@ -434,7 +428,13 @@ def get_port_from_port_server(portserver_address, pid=None):
     return port
 
 
-GetPortFromPortServer = get_port_from_port_server  # legacy API. pylint: disable=invalid-name
+# Legacy APIs.
+# pylint: disable=invalid-name
+Bind = bind
+GetPortFromPortServer = get_port_from_port_server
+IsPortFree = is_port_free
+PickUnusedPort = pick_unused_port
+# pylint: enable=invalid-name
 
 
 def main(argv):

--- a/src/portpicker.py
+++ b/src/portpicker.py
@@ -265,6 +265,9 @@ def _spawn_bound_port_holding_daemon(port, bound_sockets, timeout):
                 # This child process inherits and holds bound_sockets open
                 # for bind_timeout seconds.
                 try:
+                    # Close the stdio fds as may be connected to
+                    # a pipe that will cause a grandparent process
+                    # to wait on before returning. (cl/427587550)
                     os.close(sys.stdin.fileno())
                     os.close(sys.stdout.fileno())
                     os.close(sys.stderr.fileno())

--- a/src/portpicker.py
+++ b/src/portpicker.py
@@ -453,7 +453,7 @@ def main(argv):
     portserver was found. If the timeout was not possible, we'll warn on stderr.
 
       #!/bin/bash
-      port="$(portpicker $$ 3.14)"
+      port="$(python -m portpicker $$ 3.14)"
       test_my_server "$port"
 
     This will pick a port for your script's PID and assign it to $port, while

--- a/src/portpicker.py
+++ b/src/portpicker.py
@@ -45,6 +45,7 @@ import os
 import random
 import socket
 import sys
+import time
 
 _winapi = None  # pylint: disable=invalid-name
 if sys.platform == 'win32':
@@ -255,7 +256,6 @@ def _spawn_bound_port_holding_daemon(port, bound_sockets, timeout):
     """
     if bound_sockets and timeout > 0:
         try:
-            import time  # pylint: disable=import-outside-toplevel
             fork_pid = os.fork()  # This concept only works on POSIX.
         except Exception as err:  # pylint: disable=broad-except
             print('WARNING: Cannot timeout unbinding close of port', port,
@@ -465,6 +465,8 @@ def main(argv):
     Older versions of portpicker ignore more than the first argument so passing
     a bind timeout value will silently have no effect on old versions.
     """
+    # Our command line is trivial so I avoid an argparse import. If we ever
+    # grow more than 1-2 args, switch to a using argparse.
     if '-h' in argv or '--help' in argv:
         print(argv[0], 'usage:')
         print(main.__doc__)

--- a/src/portpicker.py
+++ b/src/portpicker.py
@@ -264,15 +264,13 @@ def _spawn_bound_port_holding_daemon(port, bound_sockets, timeout):
             if fork_pid == 0:
                 # This child process inherits and holds bound_sockets open
                 # for bind_timeout seconds.
-                try:
-                    os.close(sys.stdin.fileno())
-                    os.close(sys.stdout.fileno())
-                    os.close(sys.stderr.fileno())
-                    time.sleep(timeout)
-                    for held_socket in bound_sockets:
-                        held_socket.close()
-                finally:  # Hide errors.
-                    sys.exit(0)
+                os.close(sys.stdin.fileno())
+                os.close(sys.stdout.fileno())
+                os.close(sys.stderr.fileno())
+                time.sleep(timeout)
+                for held_socket in bound_sockets:
+                    held_socket.close()
+                sys.exit(0)
 
 
 def _pick_unused_port_without_server(bind_timeout=0):

--- a/src/portpicker.py
+++ b/src/portpicker.py
@@ -153,11 +153,8 @@ def _bind(port, socket_type, socket_proto, return_socket=None,
         finally:
             if return_socket is not None and family == return_family:
                 return_socket.append(sock)
-                # Guaranteed last iteration due to pre-loop logic. This
-                # just makes it clear no more iterations are useful.
-                break
-            else:
-                sock.close()
+                break  # Final iteration due to pre-loop logic; don't close.
+            sock.close()
     return port if got_socket else None
 
 

--- a/src/tests/portpicker_test.py
+++ b/src/tests/portpicker_test.py
@@ -100,7 +100,7 @@ class PickUnusedPortTestWithAPortServer(CommonTestMixin, unittest.TestCase):
         if cls.portserver_process:
             if os.environ.get('PORTSERVER_ADDRESS') == cls.portserver_address:
                 del os.environ['PORTSERVER_ADDRESS']
-            if cls.portserver_process.poll() is not None:
+            if cls.portserver_process.poll() is None:
                 cls.portserver_process.kill()
                 cls.portserver_process.wait()
             cls.portserver_process = None

--- a/src/tests/portpicker_test.py
+++ b/src/tests/portpicker_test.py
@@ -478,6 +478,13 @@ class PortpickerCommandLineTests(unittest.TestCase):
         self.assertIn('usage', cmd.stdout)
         self.assertIn('passed an arg', cmd.stdout)
 
+    def test_command_line_help_text_dedented(self):
+        cmd = self._run_portpicker(['-h'])
+        self.assertNotEqual(0, cmd.returncode)
+        self.assertIn('\nIf passed an arg', cmd.stdout)
+        self.assertIn('\n  #!/bin/bash', cmd.stdout)
+        self.assertIn('\nOlder versions ', cmd.stdout)
+
     def test_command_line_interface(self):
         cmd = self._run_portpicker([str(os.getpid())])
         cmd.check_returncode()

--- a/src/tests/portpicker_test.py
+++ b/src/tests/portpicker_test.py
@@ -443,9 +443,7 @@ def get_open_listen_tcp_ports():
     return listen_ports
 
 
-@unittest.skipUnless((sys.executable and os.access(sys.executable, os.X_OK)
-                      and portpicker.__file__ and
-                      os.access(portpicker.__file__, os.R_OK))
+@unittest.skipUnless((sys.executable and os.access(sys.executable, os.X_OK))
                      or (os.environ.get('TEST_PORTPICKER_CLI') and
                          os.access(os.environ['TEST_PORTPICKER_CLI'], os.X_OK)),
                      'sys.executable portpicker.__file__ not launchable and '
@@ -461,7 +459,7 @@ class PortpickerCommandLineTests(unittest.TestCase):
         if os.environ.get('TEST_PORTPICKER_CLI'):
             pp_command = [os.environ['TEST_PORTPICKER_CLI']]
         else:
-            pp_command = [sys.executable, self.main_py]
+            pp_command = [sys.executable, '-m', 'portpicker']
         return subprocess.run(pp_command + pp_args,
                               capture_output=True, env=env, encoding='utf-8')
 

--- a/src/tests/portpicker_test.py
+++ b/src/tests/portpicker_test.py
@@ -31,6 +31,8 @@ from unittest import mock
 import portpicker
 _winapi = portpicker._winapi
 
+# pylint: disable=invalid-name,protected-access,missing-class-docstring,missing-function-docstring
+
 
 class CommonTestMixin:
     def IsUnusedTCPPort(self, port):
@@ -77,7 +79,7 @@ class PickUnusedPortTestWithAPortServer(CommonTestMixin, unittest.TestCase):
                 try:
                     ps_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
                     ps_sock.connect(linux_addr)
-                except socket.error as err:
+                except socket.error as err:  # pylint: disable=unused-variable
                     continue
                 ps_sock.close()
                 break
@@ -461,7 +463,10 @@ class PortpickerCommandLineTests(unittest.TestCase):
         else:
             pp_command = [sys.executable, '-m', 'portpicker']
         return subprocess.run(pp_command + pp_args,
-                              capture_output=True, env=env, encoding='utf-8')
+                              capture_output=True,
+                              env=env,
+                              encoding='utf-8',
+                              check=False)
 
     def test_command_line_help(self):
         cmd = self._run_portpicker(['-h'])
@@ -504,7 +509,9 @@ class PortpickerCommandLineTests(unittest.TestCase):
         if 'WARNING' in cmd.stderr:
             raise unittest.SkipTest('bind timeout not supported on this platform.')
         listen_ports = sorted(get_open_listen_tcp_ports())
-        self.assertIn(port, listen_ports, msg='expected port to be bound. %f seconds elapsed of %f bind timeout.' % (time.monotonic() - before, timeout))
+        self.assertIn(port, listen_ports, msg='expected port to be bound. '
+                      '%f seconds elapsed of %f bind timeout.' %
+                      (time.monotonic() - before, timeout))
 
 
 if __name__ == '__main__':

--- a/src/tests/portpicker_test.py
+++ b/src/tests/portpicker_test.py
@@ -448,7 +448,10 @@ class PortpickerCommandLineTests(unittest.TestCase):
     def setUp(self):
         self.main_py = portpicker.__file__
 
-    def _run_portpicker(self, pp_args, env=None):
+    def _run_portpicker(self, pp_args, env_override=None):
+        env = dict(os.environ)
+        if env_override:
+            env.update(env_override)
         return subprocess.run([sys.executable, self.main_py] + pp_args,
                               capture_output=True, env=env, encoding='utf-8')
 
@@ -472,7 +475,7 @@ class PortpickerCommandLineTests(unittest.TestCase):
 
     def test_command_line_interface_no_portserver(self):
         cmd = self._run_portpicker([str(os.getpid())],
-                                   env={'PORTSERVER_ADDRESS': ''})
+                                   env_override={'PORTSERVER_ADDRESS': ''})
         cmd.check_returncode()
         port = int(cmd.stdout)
         self.assertNotEqual(0, port, msg=cmd)
@@ -486,7 +489,7 @@ class PortpickerCommandLineTests(unittest.TestCase):
         timeout = 9.5
         before = time.monotonic()
         cmd = self._run_portpicker([str(os.getpid()), str(timeout)],
-                                   env={'PORTSERVER_ADDRESS': ''})
+                                   env_override={'PORTSERVER_ADDRESS': ''})
         self.assertEqual(0, cmd.returncode, msg=(cmd.stdout, cmd.stderr))
         port = int(cmd.stdout)
         self.assertNotEqual(0, port, msg=cmd)


### PR DESCRIPTION
This is for CLI users in the non-recommended non-portserver case. The logic here comes from our internal `googletest.sh` bash testing framework to replace existing `perl -e` and `python -c` invocations that currently attempt an equivalent. This feature allows us to change it to always prefer invoking portpicker.

This also enhances the testing so that portpicker portserver usage is covered in CI by launching our own portserver when feasible. Likely only on Linux or posixy things as written today. Tests are skipped when doing that doesn't seem possible.

No public API changes aside from the additional optional portpicker command line argument and `--help` / `-h` support.