### PR TITLE
Call `shutdown()` before `close()` to resolve potential flakiness.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,12 @@
+## 1.6.0
+
+*   Resolve an internal source of potential flakiness on the bind/close port
+    checks when used in active environments by calling `.shutdown()` before
+    `.close()`.
+
 ## 1.6.0b1
 
-*   Add -h and --help text to the command line tool.
+*   Add `-h` and `--help` text to the command line tool.
 *   The command line interface now defaults to associating the returned port
     with its parent process PID (usually the calling script) when no argument
     was given as that makes more sense.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 # https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files
 [metadata]
 name = portpicker
-version = 1.6.0b1
+version = 1.6.0
 maintainer = Google LLC
 maintainer_email = greg@krypto.org
 license = Apache 2.0
@@ -27,6 +27,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
 platforms = POSIX, Windows

--- a/src/portpicker.py
+++ b/src/portpicker.py
@@ -155,6 +155,14 @@ def _bind(port, socket_type, socket_proto, return_socket=None,
             return None
         finally:
             if return_socket is None or family != return_family:
+                try:
+                    # Adding this resolved 1 in ~500 flakiness that we were
+                    # seeing from an integration test framework managing a set
+                    # of ports with is_port_free().  close() doesn't move the
+                    # TCP state machine along quickly.
+                    sock.shutdown(socket.SHUT_RDWR)
+                except OSError:
+                    pass
                 sock.close()
         if return_socket is not None and family == return_family:
             return_socket.append(sock)


### PR DESCRIPTION
Bumps the version to 1.6.0 for a new official release.

Internally, see b/294794967#comment53